### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -21,7 +21,7 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @items = Item.where(params[:id])
+    @item = Item.find(params[:id])
   end
 
   def edit

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
 
-  before_action :authenticate_user!, only:[:new] 
+  before_action :authenticate_user!, only:[:new, :destroy, :edit] 
 
   def index
     @items = Item.order("created_at DESC")
@@ -20,11 +20,20 @@ class ItemsController < ApplicationController
     @item = Item.new
   end
 
+  def show
+    @items = Item.where(params[:id])
+  end
+
+  def edit
+  end
+
   private
 
   def item_params
     params.require(:item).permit(:image, :item_name, :explain, :price, :category_id, :delivery_cost_id, :condition_id, :delivery_day_id, :delivery_place_id).merge(user_id: current_user.id)
   end
 
+  def destroy
+  end
 
 end

--- a/app/models/delivery_day.rb
+++ b/app/models/delivery_day.rb
@@ -1,9 +1,9 @@
 class DeliveryDay < ActiveHash::Base
   self.data = [
   { id: 0, name: '--' },
-  { id: 1, name: '1~2で発送' },
-  { id: 2, name: '2~3で発送' },
-  { id: 3, name: '4~7で発送' }
+  { id: 1, name: '1~2日で発送' },
+  { id: 2, name: '2~3日で発送' },
+  { id: 3, name: '4~7日で発送' }
   ]
   include ActiveHash::Associations
   has_many :items

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
     <% @items.each do |item| %>
       <li class='list'>
     
-      <%= link_to "#" do %>
+      <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,13 +1,14 @@
 <%= render "shared/header" %>
 
 <%# 商品の概要 %>
+<% @items.each do |item| %>
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= item.item_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag item.image,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,21 +17,24 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= item.delivery_cost.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+  <% if user_signed_in? && current_user.id == item.user.id%>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
+  <% end %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
+
+  <% if user_signed_in? && current_user.id != item.user.id %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
 
@@ -43,27 +47,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= item.delivery_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= item.delivery_place.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= item.delivery_day.name %></td>
         </tr>
       </tbody>
     </table>
@@ -105,6 +109,7 @@
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+<% end %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -22,14 +22,14 @@
     </div>
 
     
-  <% if user_signed_in? && current_user.id == item.user.id%>
+  <% if user_signed_in? && current_user.id == @item.user.id%>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
   <% end %>
     
 
-  <% if user_signed_in? && current_user.id != item.user.id %>
+  <% if user_signed_in? && current_user.id != @item.user.id %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <% end %>
     

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,14 +1,11 @@
 <%= render "shared/header" %>
-
-<%# 商品の概要 %>
-<% @items.each do |item| %>
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= item.item_name %>
+      <%= @item.item_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag item.image,class:"item-box-img" %>
+      <%= image_tag @item.image,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -17,29 +14,25 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        <%= item.price %>円
+        <%= @item.price %>円
       </span>
       <span class="item-postage">
-        <%= item.delivery_cost.name %>
+        <%= @item.delivery_cost.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    
   <% if user_signed_in? && current_user.id == item.user.id%>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
   <% end %>
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    
 
   <% if user_signed_in? && current_user.id != item.user.id %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <% end %>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
     </div>
@@ -47,27 +40,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= item.user.nickname %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= item.category.name %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= item.condition.name %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= item.delivery_cost.name %></td>
+          <td class="detail-value"><%= @item.delivery_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= item.delivery_place.name %></td>
+          <td class="detail-value"><%= @item.delivery_place.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= item.delivery_day.name %></td>
+          <td class="detail-value"><%= @item.delivery_day.name %></td>
         </tr>
       </tbody>
     </table>
@@ -82,7 +75,6 @@
       </div>
     </div>
   </div>
-  <%# /商品の概要 %>
 
   <div class="comment-box">
     <form>
@@ -107,9 +99,8 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-<% end %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -17,7 +17,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        <%= item.price %>
+        <%= item.price %>円
       </span>
       <span class="item-postage">
         <%= item.delivery_cost.name %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -34,7 +34,7 @@
     <% end %>
     
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.explain %></span>
     </div>
     <table class="detail-table">
       <tbody>


### PR DESCRIPTION
#what
商品の詳細ページ遷移

#why
商品の詳細を表示するため

gyazoです

ログイン状態且つ自分の商品の詳細ページに移動
https://gyazo.com/ac8e498855622a6a566e5594a943c14e

ログイン状態且つ他人の商品の詳細ページに移動
https://gyazo.com/2e757265b04d7ac9d13e55f73e716b49

ログアウト状態且つ商品の詳細ページに移動
https://gyazo.com/57b966abbb9b35c9af3b6a10939b7ee9

まだ、購入機能の実装をしていないので、ログイン状態で売却済みの商品の詳細ページへの遷移の動画はありません。

確認お願いします
